### PR TITLE
Add crafting materials and profit overview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1706,3 +1706,20 @@ select.input-field option {
 }
 
 /* Ende der Modal Styles */
+
+/* Calculator table */
+.calculator-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.calculator-table th,
+.calculator-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.calculator-table tfoot td {
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- allow selecting crafting materials when creating or editing items
- store selected materials for each item
- show profit, material cost and margin in items list and new calculator tab
- implement calculator overview table with totals
- style calculator table

## Testing
- `npx eslint *.js` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_686fed8674088324ac6eb67c60f0a010